### PR TITLE
wrap node-sass and build binaries separately fixes #23

### DIFF
--- a/emails.coffee
+++ b/emails.coffee
@@ -33,8 +33,6 @@ Mailer =
 
 # ## Deps
 #
-# Use `juice` for inlining CSS into the templates.
-juice = Npm.require 'juice'
 Utils = share.MailerUtils
 
 # ## Template helpers
@@ -349,16 +347,16 @@ MailerClass = (options) ->
       # Typically `/emails/preview/myEmailTemplate`.
       # Do some formatting. The `path` should be the prefix, followed by
       # the type (`preview` or `send`). So it could look like
-      # 
+      #
       #    /emails/preview/sampleTemplate/:param
-      # 
+      #
       # Also capitalize the first character in the template name for
-      # the name of the route, so it will look like `previewSample` for a 
+      # the name of the route, so it will look like `previewSample` for a
       # template named `sample`.
       path = "#{settings.routePrefix}/#{type}" + template.route.path
       name = Utils.capitalizeFirstChar(template.name)
       routeName = "#{type}#{name}"
-      
+
       Utils.Logger.info "Add route: [#{routeName}] at path /" + path, TAG
 
       Router.route routeName,

--- a/package.js
+++ b/package.js
@@ -7,11 +7,6 @@ Package.describe({
   git: 'https://github.com/lookback/meteor-emails.git'
 });
 
-Npm.depends({
-  'node-sass': '3.2.0',
-  'juice': '1.0.0'
-});
-
 Package.onUse(function(api) {
 
   api.versionsFrom('1.0.4');
@@ -21,6 +16,8 @@ Package.onUse(function(api) {
     'underscore',
     'coffeescript',
     'email',
+    'sacha:juice',
+    'chrisbutler:node-sass',
     'iron:router@1.0.7',
     'meteorhacks:ssr@2.1.2'
   ], where);

--- a/utils.coffee
+++ b/utils.coffee
@@ -2,7 +2,6 @@
 
 fs = Npm.require 'fs'
 path = Npm.require 'path'
-sass = Npm.require 'node-sass'
 
 # This package assumes that assets (templates, SCSS, CSS ..) are
 # stored in the `private` directory. Thanks to that, Meteor won't


### PR DESCRIPTION
hey johanbrook, i was able to get this working again on linux (ubuntu) and osx by creating a wrapper for node-sass. 

this makes more sense than having to re-build this package for each platform every time you update it. i also switched juice to use sacha's wrapper which serves the same purpose. 
