### PR TITLE
Fix typos in Mailer Config

### DIFF
--- a/example/server/server.js
+++ b/example/server/server.js
@@ -1,6 +1,6 @@
 Mailer.config({
-  from: 'John Doe <from@domain.com',
-  replyTo: 'John Doe <from@domain.com'
+  from: 'John Doe <from@domain.com>',
+  replyTo: 'John Doe <from@domain.com>'
 });
 
 Meteor.startup(function() {


### PR DESCRIPTION
This should make the example email addresses be formatted correctly.
