### PR TITLE
Make node-sass opt in.

### DIFF
--- a/.versions
+++ b/.versions
@@ -23,7 +23,7 @@ iron:url@1.0.7
 jquery@1.11.3_2
 json@1.0.3
 logging@1.0.7
-lookback:emails@0.4.5
+lookback:emails@0.4.6
 meteor@1.1.6
 meteorhacks:ssr@2.1.2
 minifiers@1.1.5

--- a/README.md
+++ b/README.md
@@ -419,6 +419,7 @@ Why not try [`meteor-logger`](https://github.com/lookback/meteor-logger)? :)
 
 ## Version history
 
+- `0.5.0` - Remove `node-sass` as hard dependency. SCSS support is now opt-in, by adding `chrisbutler:node-sass` to your app.
 - `0.4.6` - Fix paths on Windows in development mode.
 - `0.4.5`
   - CSS and SCSS is now compiled and inlined at runtime, in order to inline CSS for the rendered content. If CSS only was inlined at compile time, the dynamic content wouldn't get any styling.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Usually, building HTML emails yourself is tedious. On top of that, add the need 
 
 - **Server side rendering** with the [Meteor SSR](https://github.com/meteorhacks/meteor-ssr/) package. Use Blaze features and helpers like on the client.
 - **CSS inlining** with [Juice](http://npmjs.org/package/juice). No extra build step.
+- **SCSS support** using `node-sass` (opt-in).
 - **Preview and debug** emails in development mode in your browser when developing.
 - **Layouts** for re-using markup.
 
@@ -24,6 +25,14 @@ meteor add lookback:emails
 [Annotated source](http://lookback.github.io/meteor-emails/docs/emails.html)
 
 A `Mailer` global will exported on the *server*.
+
+**Notice.** If you want SCSS support, be sure to add the `[meteor-node-sass](https://github.com/chrisbutler/meteor-node-sass)` package to your app:
+
+```
+meteor add chrisbutler:node-sass
+```
+
+`lookback:emails` will automatically detect `node-sass` being available, and will be able to compile `.scss` files.
 
 ## Sample app
 

--- a/example/.meteor/packages
+++ b/example/.meteor/packages
@@ -8,3 +8,4 @@ meteor-platform
 autopublish
 insecure
 lookback:emails
+chrisbutler:node-sass@3.2.0

--- a/example/.meteor/versions
+++ b/example/.meteor/versions
@@ -33,7 +33,7 @@ json@1.0.3
 launch-screen@1.0.2
 livedata@1.0.13
 logging@1.0.7
-lookback:emails@0.4.5
+lookback:emails@0.4.6
 meteor@1.1.6
 meteor-platform@1.2.2
 meteorhacks:ssr@2.1.2

--- a/example/.meteor/versions
+++ b/example/.meteor/versions
@@ -33,7 +33,7 @@ json@1.0.3
 launch-screen@1.0.2
 livedata@1.0.13
 logging@1.0.7
-lookback:emails@0.4.6
+lookback:emails@0.5.0
 meteor@1.1.6
 meteor-platform@1.2.2
 meteorhacks:ssr@2.1.2

--- a/example/private/layout.scss
+++ b/example/private/layout.scss
@@ -1,5 +1,7 @@
+$color: #333;
+
 body, p {
   font-family: sans-serif;
-  color: #333;
+  color: $color;
   text-align: center;
 }

--- a/package.js
+++ b/package.js
@@ -11,13 +11,14 @@ Package.onUse(function(api) {
 
   api.versionsFrom('1.0.4');
 
+  api.use('chrisbutler:node-sass@3.2.0', where, { weak: true });
+
   api.use([
     'check',
     'underscore',
     'coffeescript',
     'email',
     'sacha:juice@0.1.3',
-    'chrisbutler:node-sass@3.2.0',
     'iron:router@1.0.7',
     'meteorhacks:ssr@2.1.2'
   ], where);

--- a/package.js
+++ b/package.js
@@ -3,7 +3,7 @@ var where = 'server';
 Package.describe({
   name: 'lookback:emails',
   summary: 'Send HTML emails with server side Blaze templates. Preview and debug in the browser.',
-  version: '0.4.6',
+  version: '0.5.0',
   git: 'https://github.com/lookback/meteor-emails.git'
 });
 

--- a/utils.coffee
+++ b/utils.coffee
@@ -103,7 +103,13 @@ Utils =
 
   # Take a path to a SCSS file and compiles it to CSS with `node-sass`.
   toCSS: (scss) ->
+    if !Package['chrisbutler:node-sass']
+      Utils.Logger.warn 'Sass support is opt-in since lookback:emails@0.5.0. Please add chrisbutler:node-sass from Atmosphere and try again.', TAG
+      # Return file contents.
+      return Utils.readFile(scss)
+
     file = path.join(ROOT, scss)
+    sass = Package['chrisbutler:node-sass'].sass
 
     try
       return sass.renderSync(file: file, sourceMap: false).css.toString()


### PR DESCRIPTION
So `node-sass` is causing some troubles for some, so this patch removes it as a hard dep. This package will automatically detect if `chrisbutler:node-sass` is added to the app, and will use that only.
