### PR TITLE
Removed Iron Router dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ In `Mailer.init`, you're able to provide a key-value object with *template objec
     teamMembers: ->
       @team.users.map (user) -> Meteor.users.findOne(user)
 
-  # For previewing the email in your browser. Behaves like an ordinary Iron Router route.  
+  # For previewing the email in your browser.
   route:
     path: '/activity/:user'
     data: ->
@@ -234,14 +234,18 @@ The built in helpers are:
 baseUrl: (path) ->
   Utils.joinUrl(Mailer.settings.baseUrl, path)
 
-# `emailUrlFor` takes an Iron Router route (with optional params) and
+# `emailUrlFor` takes an Iron Router or Flow Router route (with optional params) and
 # creates an absolute URL.
 #
 #     {{ emailUrlFor 'myRoute' param='foo' }} => http://root-domain.com/my-route/foo
-emailUrlFor: (route, params) ->
-  if Router
-    Utils.joinUrl Mailer.settings.baseUrl, Router.path.call(Router, route, params.hash)
+  emailUrlFor: (routeName, params) ->
+    # if Iron Router
+    if Router?
+      Utils.joinUrl Mailer.settings.baseUrl, Router.path.call(Router, routeName, params.hash)
 
+    # if Flow Router
+    if FlowRouter?
+      baseUrl = Utils.joinUrl Mailer.settings.baseUrl, FlowRouter.path.call(FlowRouter, routeName, params.hash)
 ```
 
 #### The preview line
@@ -362,9 +366,9 @@ Consult the `html-to-text` [documentation](https://www.npmjs.com/package/html-to
 
 It's also possible to *send* emails to yourself or others for review in a real mail client.
 
-Noticed the `route` property on the template? It uses Iron Router's server side routes under the hood.
+Noticed the `route` property on the template? It uses `meteorhacks:picker` server side routes under the hood.
 
-The `route` property expects a `path` property (feel free to use any of Iron Router's fanciness in here) and an optional `data` function providing the data context (an object). The function has access to the same scope as Iron Router's `action` hook, which means you can get a hold of parameters and the whole shebang.
+The `route` property expects a `path` property and an optional `data` function providing the data context (an object). The function has access to the parameters of the route.
 
 **Three routes** will be added:
 
@@ -375,7 +379,7 @@ The `route` property expects a `path` property (feel free to use any of Iron Rou
 ```
 The `/emails` root prefix is configurable in `config` in the `routePrefix` key.
 
-The Iron Router *route names* will be on the format
+The *route names* will be on the format
 
 ```
 [preview|send]Name
@@ -464,6 +468,7 @@ Why not try [`meteor-logger`](https://github.com/lookback/meteor-logger)? :)
 
 ## Version history
 
+- `0.7.0` - Replaced Iron Router dependency with `meteorhacks:picker`, which means you can now use this package with Flow Router as well.
 - `0.6.2` - Support passing options to `html-to-text` module in `Mailer.config()`.
 - `0.6.1`- Fix critical runtime crash when sending emails.
 - `0.6.0` - Automatically create and include plain text email version from your HTML templates, using [`html-to-text`](http://npmjs.com/package/html-to-text).

--- a/README.md
+++ b/README.md
@@ -238,15 +238,17 @@ baseUrl: (path) ->
 # creates an absolute URL.
 #
 #     {{ emailUrlFor 'myRoute' param='foo' }} => http://root-domain.com/my-route/foo
-  emailUrlFor: (routeName, params) ->
-    # if Iron Router
-    if Router?
-      Utils.joinUrl Mailer.settings.baseUrl, Router.path.call(Router, routeName, params.hash)
+emailUrlFor: (routeName, params) ->
+  # if Iron Router
+  if Router?
+    Utils.joinUrl Mailer.settings.baseUrl, Router.path.call(Router, routeName, params.hash)
 
-    # if Flow Router
-    if FlowRouter?
-      baseUrl = Utils.joinUrl Mailer.settings.baseUrl, FlowRouter.path.call(FlowRouter, routeName, params.hash)
+  # if Flow Router
+  if FlowRouter?
+    baseUrl = Utils.joinUrl Mailer.settings.baseUrl, FlowRouter.path.call(FlowRouter, routeName, params.hash)
 ```
+
+Please note that for Flow Router you need to have your routes defined in a place where the server can see them, in order for the `emailUrlFor` helper to work.
 
 #### The preview line
 

--- a/package.js
+++ b/package.js
@@ -3,7 +3,7 @@ var where = 'server';
 Package.describe({
   name: 'lookback:emails',
   summary: 'Send HTML emails with server side Blaze templates. Preview and debug in the browser.',
-  version: '0.6.2',
+  version: '0.7.0',
   git: 'https://github.com/lookback/meteor-emails.git'
 });
 
@@ -23,8 +23,8 @@ Package.onUse(function(api) {
     'coffeescript',
     'email',
     'sacha:juice@0.1.3',
-    'iron:router@1.0.7',
-    'meteorhacks:ssr@2.1.2'
+    'meteorhacks:ssr@2.1.2',
+    'meteorhacks:picker@1.0.3'
   ], where);
 
   api.addFiles([


### PR DESCRIPTION
Replaced Iron Router dependency with `meteorhacks:picker`, which means you can now use this package with Flow Router as well:

Uses `meteorhacks:picker` for server side routing
`emailForUrl` helper supports both Iron Router and Flow Router
Updated readme

Bumped to v0.7.0 - I thought it was quite major ;-)
