### PR TITLE
Attachments support

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,8 @@ Please inspect the provided sample code for details.
     from: 'Name <name@domain.com>',         // Override global 'From: ' option.
     cc: 'Name <name@domain.com>',           // Optional.
     bcc: 'Name <name@domain.com>',          // Optional.
-    data: {}                                // Optional. Render your email with a data object.
+    data: {},                               // Optional. Render your email with a data object.
+    attachments: {}                         // Optional. Attach files using a mailcomposer format.
   }
     ```
 

--- a/lib/mailer.js
+++ b/lib/mailer.js
@@ -233,7 +233,8 @@ const factory = (options) => {
       replyTo: Match.Optional(Match.OneOf(String, [String])),
       from: Match.Optional(String),
       data: Match.Optional(Object),
-      headers: Match.Optional(Object)
+      headers: Match.Optional(Object),
+      attachments: Match.Optional([Object])
     });
 
     const defaults = {


### PR DESCRIPTION
Hi!
This pull request allows to add attachments using meteor's underlying mailcomposer package syntax: (see https://github.com/nodemailer/mailcomposer#attachments).
