### PR TITLE
Use packages from npm and support more FlowRouter forks

### DIFF
--- a/lib/mailer.js
+++ b/lib/mailer.js
@@ -25,6 +25,7 @@ const TAG = 'mailer';
 export const Mailer = {
   settings: {
     silent: false,
+    silentRouteAdd: false,
     routePrefix: 'emails',
     baseUrl: process.env.ROOT_URL,
     testEmail: null,

--- a/lib/routing.js
+++ b/lib/routing.js
@@ -148,7 +148,9 @@ export default function Routing(template, settings, render, compile) {
     const name = Utils.capitalizeFirstChar(template.name);
     const routeName = String(type + name);
 
-    Utils.Logger.info(`Add route: [${routeName}] at path ${path}`);
+    if (!settings.silentRouteAdd) {
+      Utils.Logger.info(`Add route: [${routeName}] at path ${path}`);
+    }
 
     Picker.route(path, (params, req, res) => action(req, res, params, template));
   });

--- a/lib/template-helpers.js
+++ b/lib/template-helpers.js
@@ -1,5 +1,9 @@
 import Utils from './utils';
 
+if (Package['ostrio:flow-router-extra']) {
+  FlowRouter = require('meteor/ostrio:flow-router-extra').FlowRouter;   // this fork doesn't use a global scope
+}
+
 // # Template helpers
 //
 // Built-in template helpers.

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -5,9 +5,10 @@ import Path from 'path';
 import { htmlToText } from 'meteor/lookback:html-to-text';
 
 const isDevEnv = process.env.NODE_ENV === 'development';
+const majorVersion = parseInt(Meteor.release.split('.')[0], 10);
 const minorVersion = parseInt(Meteor.release.split('.')[1], 10);
 
-const isModernMeteor = minorVersion >= 3;
+const isModernMeteor = majorVersion > 1 || minorVersion >= 3;
 
 // since meteor 1.3 we no longer need meteor hacks just use the npm version
 const sass = (function() {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -2,7 +2,8 @@
 
 import fs from 'fs';
 import Path from 'path';
-import { htmlToText } from 'meteor/lookback:html-to-text';
+var htmlToText = Npm.require('html-to-text');
+var juice = Npm.require('juice');
 
 const isDevEnv = process.env.NODE_ENV === 'development';
 const majorVersion = parseInt(Meteor.release.split('.')[0], 10);

--- a/package.js
+++ b/package.js
@@ -3,8 +3,8 @@ var where = 'server';
 
 Package.describe({
   name: 'lookback:emails',
-  summary: 'Send HTML emails with server side Blaze templates. Preview and debug in the browser.',
-  version: '0.7.7',
+  summary: 'Send HTML emails with server-side Blaze templates. Preview and debug in the browser.',
+  version: '0.7.8',
   git: 'https://github.com/lookback/meteor-emails.git'
 });
 

--- a/package.js
+++ b/package.js
@@ -15,7 +15,9 @@ Package.onUse(function(api) {
   api.use([
     'chrisbutler:node-sass@3.2.0',
     'iron:router@1.0.7',
-    'kadira:flow-router@2.9.0'
+    'kadira:flow-router@2.9.0',
+    'staringatlights:flow-router',
+    'ostrio:flow-router-extra'
   ], where, { weak: true });
 
   api.use([

--- a/package.js
+++ b/package.js
@@ -8,6 +8,11 @@ Package.describe({
   git: 'https://github.com/lookback/meteor-emails.git'
 });
 
+Npm.depends({
+  'html-to-text': '4.0.0',
+  'juice': '4.3.1'
+});
+
 Package.onUse(function(api) {
 
   api.versionsFrom('1.0.4');
@@ -25,10 +30,8 @@ Package.onUse(function(api) {
     'check',
     'underscore',
     'email',
-    'sacha:juice@0.1.3',
     'meteorhacks:ssr@2.2.0',
-    'meteorhacks:picker@1.0.3',
-    'lookback:html-to-text@2.1.3_2'
+    'meteorhacks:picker@1.0.3'
   ], where);
 
   api.addFiles([

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lookback-emails",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "description": "`lookback:emails` is a Meteor package that makes it easier to build, test and debug rich HTML emails.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
These modifications remove the `html-to-text` and `juice` Meteor packages and instead use the npm packages directly.

I've also added weak dependencies to `staringatlights:flow-router` and `ostrio:flow-router-extra`, and some code to support the latter's lack of a global `FlowRouter` variable.

There's also a new "silentRouteAdd" setting that doesn't change anything if not set.