### PR TITLE
Upgrading node-sass version to 4.11 in example project

### DIFF
--- a/.example/package.json
+++ b/.example/package.json
@@ -8,6 +8,6 @@
   "author": "Johan Brook",
   "license": "MIT",
   "dependencies": {
-    "node-sass": "^3.8.0"
+    "node-sass": "^4.11.0"
   }
 }


### PR DESCRIPTION
The 3.8 version is no longer available on github hence the example project didn't build any more